### PR TITLE
Fix bug where entering space as command causes a crash

### DIFF
--- a/src/main/java/seedu/duke/CommandList.java
+++ b/src/main/java/seedu/duke/CommandList.java
@@ -1,5 +1,7 @@
 package seedu.duke;
 
+import seedu.duke.exceptions.CustomException;
+
 public enum CommandList {
 
     TOPIC, HELP, SOLUTION, EXPLAIN, RESULTS, TIMED_MODE, BYE, CUSTOM, CHECKPOINT, INVALID;
@@ -17,6 +19,7 @@ public enum CommandList {
     private static final String PATTERN_HELP = "(?i)help\\s*(\\w*)";
 
     private static final String PATTERN_RESULTS = "(?i)results\\s*(\\d+)";
+    private static final int FIRST_COMMAND_PARAM_INDEX = 0;
 
     public static String getTopicPattern() {
         return PATTERN_TOPIC;
@@ -26,9 +29,16 @@ public enum CommandList {
         return PATTERN_SOLUTION;
     }
 
-    public static CommandList getCommandToken(String command) {
+    public static CommandList getCommandToken(String command) throws CustomException {
         String[] splitCommand = command.split(" ");
-        String mainCommand = splitCommand[0].toLowerCase();
+        String mainCommand;
+
+        try {
+            mainCommand = splitCommand[FIRST_COMMAND_PARAM_INDEX].toLowerCase();
+        }
+        catch (ArrayIndexOutOfBoundsException error) {
+            throw new CustomException("That's an invalid command");
+        }
 
         if (mainCommand.contentEquals("topic")) {
             return TOPIC;

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -53,6 +53,7 @@ public class Parser {
 
     private static final String MESSAGE_UNSPECIFIED_TIME = "Please specify a time limit";
     private static final String MESSAGE_INVALID_TIME = "Time limit must be more than 0 seconds";
+    private static final String MESSAGE_INVALID_COMMAND = "That's an invalid command.";
 
     // non-constant attributes
     private boolean isTimedMode = false;
@@ -105,6 +106,8 @@ public class Parser {
                 processListCommand(topicList, ui);
             } else if (!lowerCaseCommand.startsWith(TIMED_MODE_PARAMETER)) {
                 throw new CustomException(MESSAGE_INVALID_COMMAND_FORMAT);
+            } else {
+                throw new CustomException(MESSAGE_INVALID_COMMAND);
             }
         }
 


### PR DESCRIPTION
Error seems to be in the getCommandToken method of the CommandList class. After splitting the command with space character as delimiter, the method tries to get the first element of the resulting array to retrieve the main command. When only space is given as input, the resulting array after splitting is empty and causes ArrayIndexOutOfBoundException error.