### PR TITLE
Bugfix undescriptive explain error

### DIFF
--- a/src/main/java/seedu/duke/CommandList.java
+++ b/src/main/java/seedu/duke/CommandList.java
@@ -14,7 +14,7 @@ public enum CommandList {
 
     private static final String PATTERN_CUSTOM = "(?i)custom";
 
-    private static final String PATTERN_EXPLANATION = "(?i)explanation\\s*(\\d+)\\s*(\\d+)";
+    private static final String PATTERN_EXPLAIN = "(?i)explain\\s*(\\d+)\\s*(.*)";
 
     private static final String PATTERN_HELP = "(?i)help\\s*(\\w*)";
 
@@ -27,6 +27,10 @@ public enum CommandList {
 
     public static String getSolutionPattern() {
         return PATTERN_SOLUTION;
+    }
+
+    public static String getExplainPattern() {
+        return PATTERN_EXPLAIN;
     }
 
     public static CommandList getCommandToken(String command) throws CustomException {
@@ -49,7 +53,7 @@ public enum CommandList {
             return CUSTOM;
         } else if (mainCommand.contentEquals("checkpoint")) {
             return CHECKPOINT;
-        } else if (mainCommand.contentEquals("explanation")) {
+        } else if (mainCommand.contentEquals("explain")) {
             return EXPLAIN;
         } else if (mainCommand.contentEquals("results")) {
             return RESULTS;
@@ -58,7 +62,7 @@ public enum CommandList {
         } else if (mainCommand.contentEquals("bye")) {
             return BYE;
         } else {
-            return INVALID;
+            throw new CustomException("That's not a valid command.");
         }
     }
 }

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -93,8 +93,9 @@ public class Parser {
             } else if (commandToken == CommandList.CHECKPOINT) {
                 handleCheckpointCommand(command, ui, topicList, questionListByTopic, allResults,
                         userAnswers, progressManager);
-            } else if (lowerCaseCommand.startsWith(EXPLAIN_PARAMETER)) {
-                processExplainCommand(lowerCaseCommand, ui, topicList, questionListByTopic);
+            } else if (commandToken == CommandList.EXPLAIN) {
+                //processExplainCommand(lowerCaseCommand, ui, topicList, questionListByTopic);
+                handleExplainCommandRegEx(command, ui, topicList, questionListByTopic);
             } else if (lowerCaseCommand.startsWith(RESULTS_PARAMETER)) {
                 processResultsCommand(lowerCaseCommand, allResults, ui, questionListByTopic, userAnswers);
             } else if (lowerCaseCommand.contentEquals(BYE_PARAMETER)) {
@@ -394,6 +395,26 @@ public class Parser {
             ui.printNoSolutionAccess();
         }
     }
+    private void handleExplainCommandRegEx(
+            String command, Ui ui, TopicList topicList, QuestionListByTopic questionListByTopic)
+            throws CustomException {
+        System.out.println("Handling explain command, using RegEx.");
+
+        Pattern explainPattern = Pattern.compile(CommandList.getExplainPattern());
+        Matcher matcher = explainPattern.matcher(command);
+        boolean foundMatch = matcher.find();
+
+        if(!foundMatch) {
+            throw new CustomException("Exception caught! You've entered an invalid format.");
+        }
+
+        String topicNumParam = matcher.group(FIRST_PARAMETER);
+        String questionNumParam = matcher.group(SECOND_PARAMETER);
+
+        int topicNum = getTopicNum(topicNumParam);
+        int questionNum = getQuestionNum(questionNumParam);
+    }
+
     //@@author ngxzs
     private void processExplainCommand(
             String lowerCaseCommand, Ui ui, TopicList topicList, QuestionListByTopic questionListByTopic)
@@ -619,6 +640,28 @@ public class Parser {
         }
         ui.askForResume();
         return true;
+    }
+
+    private int getQuestionNum (String input) throws CustomException {
+        System.out.println("Attempting to get question number.");
+        System.out.println("You've entered question num param: " + input);
+
+        final int DUMMY_NUM = 0;
+        return DUMMY_NUM;
+    }
+
+    private int getTopicNum (String topicNumParam) throws CustomException {
+        System.out.println("Attempting to get topic number.");
+        System.out.println("You've entered topic num param: " + topicNumParam);
+
+        try {
+            int topicNum = Integer.parseInt(topicNumParam);
+            System.out.println("Topic num param interpreted as: " + topicNum);
+            return topicNum;
+        }
+        catch (NumberFormatException error) {
+            throw new CustomException("Exception caught! Unable to parse topic number provided.");
+        }
     }
 }
 

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -411,8 +411,26 @@ public class Parser {
         String topicNumParam = matcher.group(FIRST_PARAMETER);
         String questionNumParam = matcher.group(SECOND_PARAMETER);
 
+        boolean isTopicNumParamWithinRange = isParamWithinIntegerRange(topicNumParam);
+        boolean isQuestionNumParamWithinRange = isParamWithinIntegerRange(questionNumParam);
+        boolean isQuestionNumParamProvided = !questionNumParam.isEmpty();
+
+        if(!isTopicNumParamWithinRange || !isQuestionNumParamWithinRange) {
+            throw new CustomException("Exception caught! You've entered a parameter that is too long.");
+        }
+
         int topicNum = getTopicNum(topicNumParam);
-        int questionNum = getQuestionNum(questionNumParam);
+        final int uninitialized = -1;
+        int questionNum = uninitialized;
+        if(isQuestionNumParamProvided) {
+            questionNum = getQuestionNum(questionNumParam);
+        }
+
+        System.out.println("Topic number and question number extracted.");
+        System.out.println("Topic number: " + topicNum);
+        System.out.println("Question number: " + (isQuestionNumParamProvided? questionNum : "no qn number given"));
+
+        System.out.println("Preparing explanation...");
     }
 
     //@@author ngxzs
@@ -642,25 +660,41 @@ public class Parser {
         return true;
     }
 
-    private int getQuestionNum (String input) throws CustomException {
-        System.out.println("Attempting to get question number.");
-        System.out.println("You've entered question num param: " + input);
+    private int getQuestionNum (String questionNumParam) throws CustomException {
+        System.out.println("You've entered question num param: \"" + questionNumParam + "\"");
 
-        final int DUMMY_NUM = 0;
-        return DUMMY_NUM;
+        try {
+            int questionNum = Integer.parseInt(questionNumParam);
+            System.out.println("Question num param interpreted as: \"" + questionNum + "\"");
+            return questionNum;
+        }
+        catch (NumberFormatException error) {
+            throw new CustomException("Exception caught! Unable to parse question number provided.");
+        }
     }
 
     private int getTopicNum (String topicNumParam) throws CustomException {
-        System.out.println("Attempting to get topic number.");
-        System.out.println("You've entered topic num param: " + topicNumParam);
+        System.out.println("You've entered topic num param: \"" + topicNumParam + "\"");
 
         try {
             int topicNum = Integer.parseInt(topicNumParam);
-            System.out.println("Topic num param interpreted as: " + topicNum);
+            System.out.println("Topic num param interpreted as: \"" + topicNum + "\"");
             return topicNum;
         }
         catch (NumberFormatException error) {
             throw new CustomException("Exception caught! Unable to parse topic number provided.");
+        }
+    }
+
+    private boolean isParamWithinIntegerRange (String param) {
+        final int maxNumOfDigits = 9;
+        int paramLength = param.length();
+
+        if(paramLength <= maxNumOfDigits) {
+            return true;
+        }
+        else {
+            return false;
         }
     }
 }

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -398,7 +398,6 @@ public class Parser {
     private void handleExplainCommandRegEx(
             String command, Ui ui, TopicList topicList, QuestionListByTopic questionListByTopic)
             throws CustomException {
-        System.out.println("Handling explain command, using RegEx.");
 
         Pattern explainPattern = Pattern.compile(CommandList.getExplainPattern());
         Matcher matcher = explainPattern.matcher(command);
@@ -419,18 +418,32 @@ public class Parser {
             throw new CustomException("Exception caught! You've entered a parameter that is too long.");
         }
 
-        int topicNum = getTopicNum(topicNumParam);
-        final int uninitialized = -1;
-        int questionNum = uninitialized;
+        final int numOfTopics = topicList.getSize();
+        int topicNum = getTopicNum(topicNumParam, numOfTopics);
+        QuestionsList qnList = questionListByTopic.getQuestionSet(topicNum - 1);
+
+        final int uninitializedQuestionNum = -1;
+        int questionNum = uninitializedQuestionNum;
+        final int numOfQuestions = qnList.getSize();
         if(isQuestionNumParamProvided) {
-            questionNum = getQuestionNum(questionNumParam);
+            questionNum = getQuestionNum(questionNumParam, numOfQuestions);
         }
 
-        System.out.println("Topic number and question number extracted.");
-        System.out.println("Topic number: " + topicNum);
-        System.out.println("Question number: " + (isQuestionNumParamProvided? questionNum : "no qn number given"));
+        boolean hasAttemptedTopicBefore = topicList.get(topicNum - 1).hasAttempted();
 
-        System.out.println("Preparing explanation...");
+        if(hasAttemptedTopicBefore) {
+            if(isQuestionNumParamProvided) {
+                String selectedExplanation = qnList.getOneExplanation(questionNum);
+                ui.printOneExplanation(questionNum, selectedExplanation);
+            }
+            else {
+                String allExplanations = qnList.getAllExplanations();
+                ui.printAllExplanations(allExplanations);
+            }
+        }
+        else {
+            ui.printNoSolutionAccess();
+        }
     }
 
     //@@author ngxzs
@@ -660,12 +673,14 @@ public class Parser {
         return true;
     }
 
-    private int getQuestionNum (String questionNumParam) throws CustomException {
-        System.out.println("You've entered question num param: \"" + questionNumParam + "\"");
+    private int getQuestionNum (String questionNumParam, int numOfQuestions) throws CustomException {
 
         try {
             int questionNum = Integer.parseInt(questionNumParam);
-            System.out.println("Question num param interpreted as: \"" + questionNum + "\"");
+
+            if(questionNum > numOfQuestions || questionNum <= 0) {
+                throw new CustomException("Exception caught! That's an invalid question number.");
+            }
             return questionNum;
         }
         catch (NumberFormatException error) {
@@ -673,12 +688,14 @@ public class Parser {
         }
     }
 
-    private int getTopicNum (String topicNumParam) throws CustomException {
-        System.out.println("You've entered topic num param: \"" + topicNumParam + "\"");
+    private int getTopicNum (String topicNumParam, int numOfTopics) throws CustomException {
 
         try {
             int topicNum = Integer.parseInt(topicNumParam);
-            System.out.println("Topic num param interpreted as: \"" + topicNum + "\"");
+
+            if(topicNum > numOfTopics || topicNum <= 0) {
+                throw new CustomException("Exception caught! You've entered an invalid topic number.");
+            }
             return topicNum;
         }
         catch (NumberFormatException error) {


### PR DESCRIPTION
Changed method to handle explain command to use RegEx instead. Should be able to provide clearer error messages for exceptions.